### PR TITLE
adding sanity checks to variables to avoid NullPointer references

### DIFF
--- a/src/BetterBurnTime.cs
+++ b/src/BetterBurnTime.cs
@@ -69,38 +69,45 @@ namespace BetterBurnTime
             logFuelCheatActivation();
             try
             {
-                ScreenSafeGUIText burnText;
-                double dVrequired;
-                if (burnVector.ebtText.enabled) {
-                    burnText = burnVector.ebtText;
-                    dVrequired = burnVector.dVremaining;
-                }
-                else
-                {
-                    burnText = ImpactTracker.BurnTimeText;
-                    dVrequired = ImpactTracker.ImpactSpeed;
-                }
-                if ((burnText == null) || !burnText.enabled || double.IsNaN(dVrequired)) return;
+				// safely initializing variables
+				ScreenSafeGUIText burnText = new ScreenSafeGUIText();
+				double dVrequired = double.NaN;
 
-                vessel.Refresh();
-                propellantsConsumed = new Tally();
-                bool isInsufficientFuel;
-                double floatBurnSeconds = GetBurnTime(dVrequired, out isInsufficientFuel);
-                int burnSeconds = double.IsInfinity(floatBurnSeconds) ? -1 : (int)(0.5 + floatBurnSeconds);
-                if (burnSeconds != lastBurnTime)
-                {
-                    lastBurnTime = burnSeconds;
-                    string burnLabel = FormatBurnTime(burnSeconds);
-                    lastUpdateText = ESTIMATED_BURN_LABEL + FormatBurnTime(burnSeconds);
-                    if (isInsufficientFuel)
-                    {
-                        lastUpdateText = ESTIMATED_BURN_LABEL + "(~" + burnLabel + ")";
-                    } else
-                    {
-                        lastUpdateText = ESTIMATED_BURN_LABEL + burnLabel;
-                    }
-                }
-               burnText.text = lastUpdateText;
+				// NullPointer check
+				if(burnVector != null) {
+					if (burnVector.ebtText.enabled) {
+						burnText = burnVector.ebtText;
+						dVrequired = burnVector.dVremaining;
+					}
+				}
+
+				// NullPointer sanity check from above
+				if(double.IsNaN(dVrequired)) {
+					burnText = ImpactTracker.BurnTimeText;
+					dVrequired = ImpactTracker.ImpactSpeed;
+				}
+
+				if (double.IsNaN(dVrequired)) return;
+
+				vessel.Refresh();
+				propellantsConsumed = new Tally();
+				bool isInsufficientFuel;
+				double floatBurnSeconds = GetBurnTime(dVrequired, out isInsufficientFuel);
+				int burnSeconds = double.IsInfinity(floatBurnSeconds) ? -1 : (int)(0.5 + floatBurnSeconds);
+				if (burnSeconds != lastBurnTime)
+				{
+					lastBurnTime = burnSeconds;
+					string burnLabel = FormatBurnTime(burnSeconds);
+					lastUpdateText = ESTIMATED_BURN_LABEL + FormatBurnTime(burnSeconds);
+					if (isInsufficientFuel)
+					{
+						lastUpdateText = ESTIMATED_BURN_LABEL + "(~" + burnLabel + ")";
+					} else
+					{
+						lastUpdateText = ESTIMATED_BURN_LABEL + burnLabel;
+					}
+				}
+				burnText.text = lastUpdateText;
             } catch (Exception e)
             {
                 burnVector.ebtText.text = e.GetType().Name + ": " + e.Message + " -> " + e.StackTrace;

--- a/src/ImpactTracker.cs
+++ b/src/ImpactTracker.cs
@@ -182,20 +182,34 @@ namespace BetterBurnTime
         {
             get
             {
-				if (!displayEnabled) return false;
-				// NullPointer check
-				if (burnVector != null) {
-					if (burnVector.ebtText.enabled) return false;
-					if (burnVector.TdnText.enabled) return false;
-				}
-                
-                // Don't display for bodies with atmospheres. (Kind of a bummer, but acceleration
-                // when someone pops a parachute gets stupidly noisy and makes for a bad experience.
-                // Just turn it off until I figure out a better solution. This can wait for
-                // a future update.
-                if (FlightGlobals.currentMainBody.atmosphere) return false;
+				bool shouldDisplay = false;
+				try {
+					// NullPointer checks
+					if (!displayEnabled) shouldDisplay = false;
+					if (burnVector == null)
+						shouldDisplay = false;
+					else if (burnVector.ebtText != null
+						&& burnVector.TdnText != null) {
+						if (burnVector.ebtText.enabled) 
+							shouldDisplay = false;
+						if (burnVector.TdnText.enabled) 
+							shouldDisplay = false;
+					}
 
-                return true;
+					// Don't display for bodies with atmospheres. (Kind of a bummer, but acceleration
+					// when someone pops a parachute gets stupidly noisy and makes for a bad experience.
+					// Just turn it off until I figure out a better solution. This can wait for
+					// a future update.
+					if (FlightGlobals.ready
+						&& FlightGlobals.currentMainBody != null 
+						&& FlightGlobals.currentMainBody.atmosphere) shouldDisplay = false;
+
+					shouldDisplay = true;
+				}catch(Exception e) {
+					Logging.Exception(e);
+				}
+
+				return shouldDisplay;
             }
         }
 

--- a/src/ImpactTracker.cs
+++ b/src/ImpactTracker.cs
@@ -182,10 +182,13 @@ namespace BetterBurnTime
         {
             get
             {
-                if (!displayEnabled) return false;
-                if (burnVector.ebtText.enabled) return false;
-                if (burnVector.TdnText.enabled) return false;
-
+				if (!displayEnabled) return false;
+				// NullPointer check
+				if (burnVector != null) {
+					if (burnVector.ebtText.enabled) return false;
+					if (burnVector.TdnText.enabled) return false;
+				}
+                
                 // Don't display for bodies with atmospheres. (Kind of a bummer, but acceleration
                 // when someone pops a parachute gets stupidly noisy and makes for a bad experience.
                 // Just turn it off until I figure out a better solution. This can wait for


### PR DESCRIPTION
Hi there, I recently realized that most of the time my kerbal was crashing there was a NullPointer reference found in the BetterBurnTime mod. I therefore modified your code to make it a littlebit more bulletproof. 
Please review and compile a new, official version so I can get rid of my own version :+1: 
