### PR TITLE
Precisely update the Est. Burn (~in)sufficient-fuel indicator

### DIFF
--- a/src/BetterBurnTime.cs
+++ b/src/BetterBurnTime.cs
@@ -26,6 +26,7 @@ namespace BetterBurnTime
         private ShipState vessel;
         private string lastUpdateText;
         private int lastBurnTime;
+        private bool wasInsufficientFuel = false;
         private int lastTimeUntilBurnStart;
         private Tally propellantsConsumed;
 
@@ -156,9 +157,10 @@ namespace BetterBurnTime
                     bool isInsufficientFuel;
                     double floatBurnSeconds = GetBurnTime(dVrequired, out isInsufficientFuel);
                     int burnSeconds = double.IsInfinity(floatBurnSeconds) ? -1 : (int)(0.5 + floatBurnSeconds);
-                    if (burnSeconds != lastBurnTime)
+                    if (burnSeconds != lastBurnTime || isInsufficientFuel != wasInsufficientFuel)
                     {
                         lastBurnTime = burnSeconds;
+                        wasInsufficientFuel = isInsufficientFuel;
                         if (isInsufficientFuel)
                         {
                             lastUpdateText = ESTIMATED_BURN_LABEL + TimeFormatter.Default.warn(burnSeconds);


### PR DESCRIPTION
Fixes KSPSnark/BetterBurnTime#5

Force a redraw of the Est. Burn text whenever the planned maneuver
crosses the insufficient-fuel boundary so that its "(~)" indicator
always displays accurate information.