### PR TITLE
Fix the max burn time calculation for unequal-density fuel mixtures

### DIFF
--- a/src/BetterBurnTime.cs
+++ b/src/BetterBurnTime.cs
@@ -316,6 +316,7 @@ namespace BetterBurnTime
                         for (int propellantIndex = 0; propellantIndex < engine.propellants.Count; ++propellantIndex)
                         {
                             Propellant propellant = engine.propellants[propellantIndex];
+                            double density = PartResourceLibrary.Instance.GetDefinition(propellant.name).density;
                             if (!ShouldIgnore(propellant.name))
                             {
                                 if (!availableResources.Has(propellant.name))
@@ -323,7 +324,7 @@ namespace BetterBurnTime
                                     isStarved = true;
                                     break;
                                 }
-                                ratioSum += propellant.ratio;
+                                ratioSum += propellant.ratio * density;
                             }
                         }
                         if (isStarved) continue;
@@ -333,9 +334,10 @@ namespace BetterBurnTime
                             for (int propellantIndex = 0; propellantIndex < engine.propellants.Count; ++propellantIndex)
                             {
                                 Propellant propellant = engine.propellants[propellantIndex];
+                                double density = PartResourceLibrary.Instance.GetDefinition(propellant.name).density;
                                 if (!ShouldIgnore(propellant.name))
                                 {
-                                    double consumptionRate = ratio * propellant.ratio * engineTotalFuelConsumption; // tons/sec
+                                    double consumptionRate = ratio * propellant.ratio * density * engineTotalFuelConsumption; // tons/sec
                                     propellantsConsumed.Add(propellant.name, consumptionRate);
                                 }
                             }


### PR DESCRIPTION
Fixes KSPSnark/BetterBurnTime#7

Take fuel density into account in the max burn time calculations, in
order to correct inaccurate results for mixtures of fuels with unequal
densities like LH2/O.

Note that stock LF/O mixture just happens to have homogeneous density,
which is why this fix wasn't "needed" for (and does not change) the LF/O
max burn time calculation.